### PR TITLE
[ Automated Merge ] : Release Build 1383 is ready for stable merge

### DIFF
--- a/s3stats-allowlist-test.yaml
+++ b/s3stats-allowlist-test.yaml
@@ -78,6 +78,7 @@
 - get_multipart_parts_request_count
 - abort_multipart_request_count
 - head_object_request_count
+- copy_object_request_count
 - put_object_request_count
 - put_object_chunkupload_request_count
 - get_object_request_count

--- a/s3stats-allowlist.yaml
+++ b/s3stats-allowlist.yaml
@@ -111,6 +111,7 @@
 - get_multipart_parts_request_count
 - abort_multipart_request_count
 - head_object_request_count
+- copy_object_request_count
 - put_object_request_count
 - put_object_chunkupload_request_count
 - get_object_request_count

--- a/server/s3_put_object_action.cc
+++ b/server/s3_put_object_action.cc
@@ -947,6 +947,14 @@ void S3PutObjectAction::set_authorization_meta() {
   s3_log(S3_LOG_DEBUG, request_id, "%s Entry\n", __func__);
   auth_client->set_acl_and_policy(bucket_metadata->get_encoded_bucket_acl(),
                                   bucket_metadata->get_policy_as_json());
+  request->reset_action_list();
+  if (!request->get_header_value("x-amz-tagging").empty()) {
+    request->set_action_list("PutObjectTagging");
+  }
+
+  if (!request->get_header_value("x-amz-acl").empty()) {
+    request->set_action_list("PutObjectACL");
+  }
   next();
   s3_log(S3_LOG_DEBUG, "", "%s Exit", __func__);
 }


### PR DESCRIPTION
RELEASE.INFO => 
 b'---\nNAME: "CORTX"\nVERSION: "2.0.0"\nBRANCH: "main"\nTHIRD_PARTY_VERSION: "centos-7.8.2003-2.0.0-7"\nBUILD: "1383"\nOS: "CentOS Linux release 7.8.2003 (Core)"\nDATETIME: "22-Jun-2021 04:30 UTC"\nKERNEL: "3.10.0_1127.el7"\nCOMPONENTS:\n    - "cortx-cli-2.0.0-849_72e58642.x86_64.rpm"\n    - "cortx-csm_agent-2.0.0-849_72e58642.x86_64.rpm"\n    - "cortx-csm_web-2.0.0-77_1efac5a.x86_64.rpm"\n    - "cortx-ha-2.0.0-110_6b35035.x86_64.rpm"\n    - "cortx-hare-2.0.0-361_git986375b.el7.x86_64.rpm"\n    - "cortx-libsspl_sec-2.0.0-121_gitd4ba2aba.el7.x86_64.rpm"\n    - "cortx-libsspl_sec-method_none-2.0.0-121_gitd4ba2aba.el7.x86_64.rpm"\n    - "cortx-motr-2.0.0-211_gite28e4d36_3.10.0_1127.el7.x86_64.rpm"\n    - "cortx-motr-ivt-2.0.0-211_gite28e4d36_3.10.0_1127.el7.x86_64.rpm"\n    - "cortx-prereq-2.0.0-172_gitaa1bcfe_el7.x86_64.rpm"\n    - "cortx-prvsnr-2.0.0-159_git1e4281cb_el7.x86_64.rpm"\n    - "cortx-py-utils-2.0.0-250_87b21d5.noarch.rpm"\n    - "cortx-s3server-2.0.0-673_gitd281cf17_el7.x86_64.rpm"\n    - "cortx-sspl-2.0.0-121_gitd4ba2aba.el7.noarch.rpm"\n    - "python36-cortx-prvsnr-2.0.52-159_git1e4281cb.x86_64.rpm"\n    - "stats_utils-2.0.0-250_87b21d5.x86_64.rpm"\n    - "uds-pyi-1.3.0-1.r10.el7.x86_64.rpm"\n    - "udx-discovery-0.1.2-3.el7.x86_64.rpm"\n'